### PR TITLE
Finish Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # hello-world
 Just another repository
+
+Số người chết do virus viêm phổi nCoV ở Trung Quốc tăng lên 213 sau khi tỉnh Hồ Bắc hôm nay thông báo có thêm 42 trường hợp tử vong.
+


### PR DESCRIPTION
Số người chết do virus viêm phổi nCoV ở Trung Quốc tăng lên 213 sau khi tỉnh Hồ Bắc hôm nay thông báo có thêm 42 trường hợp tử vong.